### PR TITLE
Move the concurrency controls here

### DIFF
--- a/.github/workflows/check-has-semver-label.yml
+++ b/.github/workflows/check-has-semver-label.yml
@@ -9,6 +9,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-has-semver-label:
     permissions:


### PR DESCRIPTION
Since check-has-semver-label-workflow can be nested into other
workflows, the concurrency should be higher up. Like here.
